### PR TITLE
docs(install): add additional context to endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ app.on("token", async ({ token, octokit }) => {
 });
 
 require("http").createServer(getNodeMiddleware(app)).listen(3000);
-// can now receive user authorization callbacks at /api/github/oauth/callback
+// or `expressApp.use(getNodeMiddleware(app));` for Express apps
 ```
+## Endpoints
+
+- Redirect to authorization prompt at `api/github/oauth/login`
+- Receive user authorization callbacks at `/api/github/oauth/callback`
 
 </td></tr>
 </tbody>

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ require("http").createServer(getNodeMiddleware(app)).listen(3000);
 ```
 ## Endpoints
 
-- Redirect to authorization prompt at `api/github/oauth/login`
+- Redirect to authorization prompt at `/api/github/oauth/login`
 - Receive user authorization callbacks at `/api/github/oauth/callback`
 
 </td></tr>


### PR DESCRIPTION
Just some really basic updates to the `README` that caught me out when I was setting up.